### PR TITLE
feat: cache Subject findAll (decrease response time)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -55,6 +55,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/ufrn/imd/boraPagar/BoraPagarApplication.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/BoraPagarApplication.java
@@ -5,12 +5,14 @@ import java.security.Principal;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
 
 
 @SpringBootApplication(exclude={DataSourceAutoConfiguration.class})
 @RestController
+@EnableCaching
 public class BoraPagarApplication {
 
 	@GetMapping

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
@@ -3,6 +3,7 @@ package ufrn.imd.boraPagar.subject;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,12 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
 
     @Autowired
     SubjectRepository subjectRepository;
+    
+
+    @Cacheable("subjects")
+    public List<SubjectModel> findAll() {
+        return subjectRepository.findAllActive();
+    }
 
     public SubjectModel findByComponentID(int id) {
         return subjectRepository.findByComponentID(id);


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR (Não é preciso pois não deve fechar a issue)
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->

O endpoint `subject/findAll` é muito custoso. São 20MB entregados em média no tempo de 14 segundos. Isso é inviável tanto na questão de memória quanto no tempo. Para que o usuário não seja prejudicado, uma primeira abordagem é diminuir o tempo de resposta das requisições adicionando o cache padrão do Spring Boot.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Adicionei a dependência de cache do spring
- Habilitei o cache na aplicação
- Sobreescri o `findAll` do `Subject` para que ele use o cache "products"

**Screenshots**
<!---
  REMOVER CASO NÃO USE.
  Se possível, adicionar imagens que ilustram o que foi desenvolvido.
-->
![image](https://github.com/isaacmsl/bora-pagar/assets/31693006/6aa29731-3f09-4833-a678-562d19fe4aee)

(O tempo está em segundos)