### PR TITLE
Feat/find all pagination

### DIFF
--- a/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractController.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractController.java
@@ -1,9 +1,11 @@
 package ufrn.imd.boraPagar.core;
 
-import java.util.List;
+// import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -26,10 +28,16 @@ public class AbstractController <M extends AbstractModel, S extends AbstractServ
     
     protected final String USER_HEADER_TOKEN_NAME = "credential";
 
+    // @GetMapping("/findAll")
+    // public ResponseEntity<List<M>> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential) {
+    //     List<M> listResult = (List<M>) service.findAll(credential);
+    //     return ResponseEntity.ok().body(listResult);
+    // }
+
     @GetMapping("/findAll")
-    public ResponseEntity<List<M>> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential) {
-        List<M> listResult = (List<M>) service.findAll(credential);
-        return ResponseEntity.ok().body(listResult);
+    public Page<M> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, Pageable pageable) {
+        Page<M> listResult = service.findAllByPage(credential, pageable);
+        return listResult;
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractController.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractController.java
@@ -1,6 +1,6 @@
 package ufrn.imd.boraPagar.core;
 
-// import java.util.List;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,11 +28,11 @@ public class AbstractController <M extends AbstractModel, S extends AbstractServ
     
     protected final String USER_HEADER_TOKEN_NAME = "credential";
 
-    // @GetMapping("/findAll")
-    // public ResponseEntity<List<M>> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential) {
-    //     List<M> listResult = (List<M>) service.findAll(credential);
-    //     return ResponseEntity.ok().body(listResult);
-    // }
+    @GetMapping("/forceFindAll")
+    public ResponseEntity<List<M>> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential) {
+        List<M> listResult = (List<M>) service.findAll(credential);
+        return ResponseEntity.ok().body(listResult);
+    }
 
     @GetMapping("/findAll")
     public Page<M> findAll(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, Pageable pageable) {

--- a/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractRepository.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractRepository.java
@@ -2,12 +2,17 @@ package ufrn.imd.boraPagar.core;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
-public interface AbstractRepository <M extends AbstractModel> extends MongoRepository<M, String> {
+public interface AbstractRepository <M extends AbstractModel> extends MongoRepository<M, String>{
     @Query("{ 'isActive' : true }")
     List<M> findAllActive();
+    
+    @Query("{ 'isActive' : true }")
+    Page<M> findAllActiveByPage(Pageable pageable);
 }

--- a/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/core/AbstractService.java
@@ -1,6 +1,8 @@
 package ufrn.imd.boraPagar.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
@@ -57,6 +59,16 @@ public abstract class AbstractService <M extends AbstractModel, R extends Abstra
         
         if (user != null) {
             return repository.findAllActive();
+        }
+
+        return null;
+    }
+
+    public Page<M> findAllByPage(String credential, Pageable pageable) {
+        UserModel user = getExistingOrNewUserFromCredential(credential);
+        
+        if (user != null) {
+            return repository.findAllActiveByPage(pageable);
         }
 
         return null;

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
@@ -2,6 +2,8 @@ package ufrn.imd.boraPagar.subject;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,11 +18,18 @@ import ufrn.imd.boraPagar.core.AbstractController;
 @RequestMapping("subjects")
 public class SubjectController extends AbstractController<SubjectModel, SubjectService>{
 
+    // @Override
+    // @GetMapping("/findAll")
+    // public ResponseEntity<List<SubjectModel>> findAll(@RequestHeader(value = USER_HEADER_TOKEN_NAME, required = false) String credential) {
+    //     List<SubjectModel> listResult = (List<SubjectModel>) service.findAll(credential);
+    //     return ResponseEntity.ok().body(listResult);
+    // }
+
     @Override
     @GetMapping("/findAll")
-    public ResponseEntity<List<SubjectModel>> findAll(@RequestHeader(value = USER_HEADER_TOKEN_NAME, required = false) String credential) {
-        List<SubjectModel> listResult = (List<SubjectModel>) service.findAll(credential);
-        return ResponseEntity.ok().body(listResult);
+    public Page<SubjectModel> findAll(@RequestHeader(value = USER_HEADER_TOKEN_NAME, required = false) String credential, Pageable pageable) {
+        Page<SubjectModel> listResult = service.findAllByPage(credential, pageable);
+        return listResult;
     }
 
     @RequestMapping(method = RequestMethod.GET, params = {"componentID"})

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
@@ -18,13 +18,6 @@ import ufrn.imd.boraPagar.core.AbstractController;
 @RequestMapping("subjects")
 public class SubjectController extends AbstractController<SubjectModel, SubjectService>{
 
-    // @Override
-    // @GetMapping("/findAll")
-    // public ResponseEntity<List<SubjectModel>> findAll(@RequestHeader(value = USER_HEADER_TOKEN_NAME, required = false) String credential) {
-    //     List<SubjectModel> listResult = (List<SubjectModel>) service.findAll(credential);
-    //     return ResponseEntity.ok().body(listResult);
-    // }
-
     @Override
     @GetMapping("/findAll")
     public Page<SubjectModel> findAll(@RequestHeader(value = USER_HEADER_TOKEN_NAME, required = false) String credential, Pageable pageable) {

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.stereotype.Service;
 
 import ufrn.imd.boraPagar.core.AbstractService;
-import ufrn.imd.boraPagar.user.UserModel;
 
 @Service
 @NoRepositoryBean
@@ -19,17 +18,7 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
     @Autowired
     SubjectRepository subjectRepository;
     
-
     @Cacheable("subjects")
-    public List<SubjectModel> findAll() {
-        return subjectRepository.findAllActive();
-    }
-
-    @Override
-    public List<SubjectModel> findAll(String credential) {
-        return subjectRepository.findAllActive();
-    }
-
     @Override
     public Page<SubjectModel> findAllByPage(String credential, Pageable pageable) {
         return subjectRepository.findAllActiveByPage(pageable);

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
@@ -4,10 +4,13 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.stereotype.Service;
 
 import ufrn.imd.boraPagar.core.AbstractService;
+import ufrn.imd.boraPagar.user.UserModel;
 
 @Service
 @NoRepositoryBean
@@ -25,6 +28,11 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
     @Override
     public List<SubjectModel> findAll(String credential) {
         return subjectRepository.findAllActive();
+    }
+
+    @Override
+    public Page<SubjectModel> findAllByPage(String credential, Pageable pageable) {
+        return subjectRepository.findAllActiveByPage(pageable);
     }
 
     public SubjectModel findByComponentID(int id) {

--- a/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
@@ -10,6 +10,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -127,6 +130,31 @@ public class SubjectTests {
     }
 
     @Test
+    public void shouldPageZeroHasLengthTwo() {
+        Pageable pageable = PageRequest.of(0, 2);
+        Page<SubjectModel> subPage = repository.findAllActiveByPage(pageable);
+
+        Assert.assertEquals(2, subPage.getContent().size());
+    }
+
+    @Test
+    public void shouldPageOneHasLengthZero() {
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<SubjectModel> subPage = repository.findAllActiveByPage(pageable);
+
+        Assert.assertEquals(0, subPage.getContent().size());
+    }
+
+    @Test
+    public void shouldPageReturnTheCorrectElements() {
+        Pageable pageable = PageRequest.of(0, 2);
+        Page<SubjectModel> subPage = repository.findAllActiveByPage(pageable);
+
+        Assert.assertEquals(subjectA, subPage.getContent().get(0));
+        Assert.assertEquals(subjectB, subPage.getContent().get(1));
+    }
+
+    @Test
     public void deleteById() {
         repository.deleteById(subjectA.getId());
         Assert.assertFalse(repository.findById(subjectA.getId()).isPresent());
@@ -137,5 +165,4 @@ public class SubjectTests {
         repository.deleteAll();
         Assert.assertEquals(0, repository.count());
     }
-
 }

--- a/backend/src/test/java/ufrn/imd/boraPagar/user/UserTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/user/UserTests.java
@@ -82,12 +82,4 @@ public class UserTests {
 
         Assert.assertEquals(0, userPage.getContent().size());
     }
-
-    // @Test
-    // public void shouldPageReturnTheCorrectElements() {
-    //     Pageable pageable = PageRequest.of(0, 2);
-    //     Page<UserModel> userPage = repository.findAllActiveByPage(pageable);
-
-    //     Assert.assertEquals(user, userPage.getContent().get(0));
-    // }
 }

--- a/backend/src/test/java/ufrn/imd/boraPagar/user/UserTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/user/UserTests.java
@@ -8,6 +8,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -63,4 +66,28 @@ public class UserTests {
     public void shouldNotFindAllByUsername() {
         Assert.assertTrue(repository.findAllByUsername("joao").isEmpty());
     }
+
+    @Test
+    public void shouldPageZeroHasLengthOne() {
+        Pageable pageable = PageRequest.of(0, 2);
+        Page<UserModel> userPage = repository.findAllActiveByPage(pageable);
+
+        Assert.assertEquals(1, userPage.getContent().size());
+    }
+
+    @Test
+    public void shouldPageOneHasLengthZero() {
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<UserModel> userPage = repository.findAllActiveByPage(pageable);
+
+        Assert.assertEquals(0, userPage.getContent().size());
+    }
+
+    // @Test
+    // public void shouldPageReturnTheCorrectElements() {
+    //     Pageable pageable = PageRequest.of(0, 2);
+    //     Page<UserModel> userPage = repository.findAllActiveByPage(pageable);
+
+    //     Assert.assertEquals(user, userPage.getContent().get(0));
+    // }
 }


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [x] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [ ] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
O endpoint `subject/findAll` é muito custoso. São `20MB` entregados em média no tempo de 14 segundos. Isso é inviável tanto na questão de memória quanto no tempo. Para que o usuário não seja prejudicado, uma segunda(pois a primeira foi usando cache) abordagem é diminuir o tempo de resposta das requisições adicionando a paginação do `findAll`.

**O que foi feito**
  -  No pacote `core` foi criado o método `findAllByPage` nos subpacotes: `repository`, `service` e `controller`.
  - Foi sobrescrito os mesmos métodos para o Subject