### PR TITLE
Fix/subject component id as string unique interested user

### DIFF
--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectController.java
@@ -27,14 +27,14 @@ public class SubjectController extends AbstractController<SubjectModel, SubjectS
 
     @JsonView(Views.Public.class)
     @PostMapping("/interested")
-    public ResponseEntity<SubjectModel> addInterestedUserSubjectCode(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, @RequestParam String code) {
-        return ResponseEntity.ok().body(service.addInterestedUserByCode(credential, code));
+    public ResponseEntity<SubjectModel> addInterestedUserByComponentID(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, @RequestParam String componentID) {
+        return ResponseEntity.ok().body(service.addInterestedUserByComponentID(credential, componentID));
     }
 
     @JsonView(Views.Public.class)
     @DeleteMapping("/interested")
-    public ResponseEntity<SubjectModel> removeInterestedUserSubjectCode(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, @RequestParam String code) {
-        return ResponseEntity.ok().body(service.removeInterestedUserByCode(credential, code));
+    public ResponseEntity<SubjectModel> removeInterestedUserByComponentID(@RequestHeader(USER_HEADER_TOKEN_NAME) String credential, @RequestParam String componentID) {
+        return ResponseEntity.ok().body(service.removeInterestedUserByComponentID(credential, componentID));
     }
     
     @Override
@@ -51,7 +51,7 @@ public class SubjectController extends AbstractController<SubjectModel, SubjectS
     }
 
     @RequestMapping(method = RequestMethod.GET, params = {"componentID"})
-    public ResponseEntity<SubjectModel> findByComponentID(@RequestParam int componentID) {
+    public ResponseEntity<SubjectModel> findByComponentID(@RequestParam String componentID) {
         return ResponseEntity.ok().body(service.findByComponentID(componentID));
     }
 

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectModel.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectModel.java
@@ -28,7 +28,7 @@ import ufrn.imd.boraPagar.user.UserModel;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SubjectModel extends AbstractModel {
-    private int componentID;
+    private String componentID;
     private String componentType, code, level, name, department;
     private int totalHours;
 

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
@@ -11,7 +11,7 @@ import ufrn.imd.boraPagar.user.UserModel;
 
 @Repository
 public interface SubjectRepository extends AbstractRepository<SubjectModel> {
-    SubjectModel findByComponentID(int componentID);
+    SubjectModel findByComponentID(String componentID);
     SubjectModel findByCode(String code);
     List<SubjectModel> findAllByModality(SubjectModalityType modality);
     List<SubjectModel> findAllByTotalHours(int totalHours);

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
@@ -22,8 +22,9 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
     @Autowired
     UserService userService;
     
-    public SubjectModel addInterestedUserByCode(String credential, String code) {
-        SubjectModel subject = subjectRepository.findByCode(code);
+    public SubjectModel addInterestedUserByComponentID(String credential, String componentID) {
+        SubjectModel subject = subjectRepository.findByComponentID(componentID);
+        System.out.println(subject);
         UserModel user = userService.getExistingOrNewUserFromCredential(credential);
         if (subject != null &&  user != null) {
             List<UserModel> interestedUsers = subject.getInterestedUsers();
@@ -36,8 +37,9 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
         return null;
     }
 
-    public SubjectModel removeInterestedUserByCode(String credential, String code) {
-        SubjectModel subject = subjectRepository.findByCode(code);
+    public SubjectModel removeInterestedUserByComponentID(String credential, String componentID) {
+        SubjectModel subject = subjectRepository.findByComponentID(componentID);
+        System.out.println(subject);
         UserModel user = userService.getExistingOrNewUserFromCredential(credential);
         if (subject != null &&  user != null) {
             List<UserModel> interestedUsers = subject.getInterestedUsers();
@@ -60,7 +62,7 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
         return subjectRepository.findAllActiveByPage(pageable);
     }
 
-    public SubjectModel findByComponentID(int id) {
+    public SubjectModel findByComponentID(String id) {
         return subjectRepository.findByComponentID(id);
     }
 

--- a/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
@@ -33,7 +33,7 @@ public class SubjectTests {
     public void setUp() throws Exception {
         subjectA = repository.save(
             new SubjectModel(
-                1,
+                "1",
                 "Disciplina",
                 "DIM1234",
                 "Gradução",
@@ -55,7 +55,7 @@ public class SubjectTests {
 
         subjectB = repository.save(
             new SubjectModel(
-                2,
+                "2",
                 "Disciplina",
                 "DIM1235",
                 "Gradução",

--- a/frontend/src/components/SubjectListItem.vue
+++ b/frontend/src/components/SubjectListItem.vue
@@ -13,7 +13,8 @@ const props = defineProps<{
   code: string;
   name: string;
   department: string;
-  interestedUsers: AppUser[]
+  interestedUsers: AppUser[];
+  componentID: string
 }>();
 
 const subjectService = new SubjectService();
@@ -27,9 +28,9 @@ async function handleInterestedUser(isAdd: boolean) {
   let subject: Subject;
 
   if (isAdd) {
-    subject = await subjectService.addInterestedUserByCode(credential, props.code);
+    subject = await subjectService.addInterestedUserByComponentID(credential, props.componentID);
   } else {
-    subject = await subjectService.removeInterestedUserByCode(credential, props.code);
+    subject = await subjectService.removeInterestedUserByComponentID(credential, props.componentID);
   }
 
   isUserInterested.value = subjectContainsInterestedUser(subject.interestedUsers);

--- a/frontend/src/services/SubjectService.ts
+++ b/frontend/src/services/SubjectService.ts
@@ -35,10 +35,10 @@ export class SubjectService {
     return response.data;
   }
 
-  public async addInterestedUserByCode(credential: string, code: string): Promise<Subject> {
+  public async addInterestedUserByComponentID(credential: string, componentID: string): Promise<Subject> {
     const response = await this.axiosInstance.post<any, AxiosResponse<Subject>>('/interested', {}, {
       params: {
-        code
+        componentID
       },
       headers: {
         credential
@@ -48,10 +48,10 @@ export class SubjectService {
     return response.data;
   }
 
-  public async removeInterestedUserByCode(credential: string, code: string): Promise<Subject> {
+  public async removeInterestedUserByComponentID(credential: string, componentID: string): Promise<Subject> {
     const response = await this.axiosInstance.delete<any, AxiosResponse<Subject>>('/interested', {
       params: {
-        code
+        componentID
       },
       headers: {
         credential

--- a/frontend/src/types/Subject.ts
+++ b/frontend/src/types/Subject.ts
@@ -2,7 +2,7 @@ import type { AppUser } from "./AppUser"
 
 export type Subject = {
     code: string
-    componentID: Number
+    componentID: string
     name: string
     department: string
     totalHours: string

--- a/frontend/src/views/SubjectList.vue
+++ b/frontend/src/views/SubjectList.vue
@@ -100,6 +100,7 @@ onMounted(async () => {
       <SubjectListItem
         v-for="subject in subjects"
         :key="subject.code"
+        :component-i-d="subject.componentID"
         :code="subject.code"
         :department="subject.department"
         :name="subject.name"

--- a/frontend/src/views/SubjectsUser.vue
+++ b/frontend/src/views/SubjectsUser.vue
@@ -51,7 +51,7 @@ onMounted(async () => {
         </header>
 
         <v-list class="list">
-            <SubjectListItem v-for="subject in subjects" :key="subject.code" :code="subject.code"
+            <SubjectListItem v-for="subject in subjects" :key="subject.code" :component-i-d="subject.componentID" :code="subject.code"
                 :department="subject.department" :name="subject.name" :interested-users="subject.interestedUsers" />
         </v-list>
 


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR
- [ ] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
Veja o problema apresentado em #129 . A funcionalidade de interested users (add/remover) deve buscar por um identificador único para que não haja problemas. Dessa forma, o `componentID` precisa ser utilizado ao invés do `code`.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Backend usa componentID como String
- Backend usa o componentID como parametro de busca nas rotas de interested users
- Frontend usa o componentID para realizar as requisicoes de interested