### PR TITLE
`findAllByNameAndDepartmentAndCode` method ignoring accent

### DIFF
--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
@@ -20,7 +20,7 @@ public interface SubjectRepository extends AbstractRepository<SubjectModel> {
     List<SubjectModel> findAllByEquivalences(SubjectModel equivalence);
     List<SubjectModel> findAllByRequirements(SubjectModel requirement);
     List<SubjectModel> findAllByCoRequirements(SubjectModel coRequirement);
-    @Query("{ $or: [ { 'name': { $regex: ?0, $options: 'i' } }, { 'department': { $regex: ?0, $options: 'i' } }, { 'code': { $regex: ?0, $options: 'i' } } ] }")
+    @Query("{ $or: [ { 'name': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } }, { 'department': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } }, { 'code': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } } ] }")
     Page<SubjectModel> findAllByNameAndDepartmentAndCode(Pageable pageable, String name, String department, String code);
     Page<SubjectModel> findAllByInterestedUsers(Pageable pageable, UserModel user);
 }

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import ufrn.imd.boraPagar.core.AbstractRepository;
@@ -20,7 +21,7 @@ public interface SubjectRepository extends AbstractRepository<SubjectModel> {
     List<SubjectModel> findAllByEquivalences(SubjectModel equivalence);
     List<SubjectModel> findAllByRequirements(SubjectModel requirement);
     List<SubjectModel> findAllByCoRequirements(SubjectModel coRequirement);
-    @Query("{ $or: [ { 'name': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } }, { 'department': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } }, { 'code': { $regex: ?0, $options: 'i', $collation: { 'locale': 'pt', 'strength': 2 } } } ] }")
-    Page<SubjectModel> findAllByNameAndDepartmentAndCode(Pageable pageable, String name, String department, String code);
+    @Query("{ $or: [ { 'name': { $regex: ?0, $options: 'i' } }, { 'department': { $regex: ?1, $options: 'i' } }, { 'code': { $regex: ?2, $options: 'i' } } ] }")
+    Page<SubjectModel> findAllByNameAndDepartmentAndCode(Pageable pageable, @Param("name") String name, @Param("department") String department, @Param("code") String code);
     Page<SubjectModel> findAllByInterestedUsers(Pageable pageable, UserModel user);
 }

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import ufrn.imd.boraPagar.core.AbstractRepository;
@@ -19,6 +20,7 @@ public interface SubjectRepository extends AbstractRepository<SubjectModel> {
     List<SubjectModel> findAllByEquivalences(SubjectModel equivalence);
     List<SubjectModel> findAllByRequirements(SubjectModel requirement);
     List<SubjectModel> findAllByCoRequirements(SubjectModel coRequirement);
-    Page<SubjectModel> findAllByNameContainingIgnoreCaseAndDepartmentContainingIgnoreCaseAndCodeContainingIgnoreCase(Pageable pageable, String name, String department, String code);
+    @Query("{ $or: [ { 'name': { $regex: ?0, $options: 'i' } }, { 'department': { $regex: ?0, $options: 'i' } }, { 'code': { $regex: ?0, $options: 'i' } } ] }")
+    Page<SubjectModel> findAllByNameAndDepartmentAndCode(Pageable pageable, String name, String department, String code);
     Page<SubjectModel> findAllByInterestedUsers(Pageable pageable, UserModel user);
 }

--- a/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
+++ b/backend/src/main/java/ufrn/imd/boraPagar/subject/SubjectService.java
@@ -84,7 +84,7 @@ public class SubjectService extends AbstractService<SubjectModel, SubjectReposit
     }
 
     public Page<SubjectModel> findAllByNameAndDepartmentAndCode(Pageable pageable, String name, String department, String code) {
-        return subjectRepository.findAllByNameContainingIgnoreCaseAndDepartmentContainingIgnoreCaseAndCodeContainingIgnoreCase(pageable, name, department, code);
+        return subjectRepository.findAllByNameAndDepartmentAndCode(pageable, name, department, code);
     }
 
 }

--- a/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
@@ -175,7 +175,7 @@ public class SubjectTests {
         String partialCode = "Di";
 
         Pageable pageable = PageRequest.of(0, 5);
-        Page<SubjectModel> subPage = repository.findAllByNameContainingIgnoreCaseAndDepartmentContainingIgnoreCaseAndCodeContainingIgnoreCase(pageable, partialName, partialDepartment, partialCode);
+        Page<SubjectModel> subPage = repository.findAllByNameAndDepartmentAndCode(pageable, partialName, partialDepartment, partialCode);
 
         Assert.assertEquals(2, subPage.getContent().size());
     }
@@ -187,7 +187,7 @@ public class SubjectTests {
         String partialCode = "21";
         
         Pageable pageable = PageRequest.of(0, 5);
-        Page<SubjectModel> subPage = repository.findAllByNameContainingIgnoreCaseAndDepartmentContainingIgnoreCaseAndCodeContainingIgnoreCase(pageable, partialName, partialDepartment, partialCode);
+        Page<SubjectModel> subPage = repository.findAllByNameAndDepartmentAndCode(pageable, partialName, partialDepartment, partialCode);
 
         Assert.assertTrue(subPage.getContent().contains(subjectB));
     }
@@ -199,7 +199,7 @@ public class SubjectTests {
         String partialCode = "";
 
         Pageable pageable = PageRequest.of(1, 5);
-        Page<SubjectModel> subPage = repository.findAllByNameContainingIgnoreCaseAndDepartmentContainingIgnoreCaseAndCodeContainingIgnoreCase(pageable, partialName, partialDepartment, partialCode);
+        Page<SubjectModel> subPage = repository.findAllByNameAndDepartmentAndCode(pageable, partialName, partialDepartment, partialCode);
 
         Assert.assertEquals(0, subPage.getContent().size());
     }

--- a/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
+++ b/backend/src/test/java/ufrn/imd/boraPagar/subject/SubjectTests.java
@@ -37,7 +37,7 @@ public class SubjectTests {
                 "Disciplina",
                 "DIM1234",
                 "Gradução",
-                "FMC 1",
+                "Fundamentos matemáticos para computação 1",
                 "DIMAp",
                 60,
                 SubjectModalityType.IN_PERSON,
@@ -59,7 +59,7 @@ public class SubjectTests {
                 "Disciplina",
                 "DIM2135",
                 "Gradução",
-                "FMC 2",
+                "Fundamentos matemáticos para computação 2",
                 "DIMAp",
                 90,
                 SubjectModalityType.IN_PERSON,
@@ -170,7 +170,7 @@ public class SubjectTests {
 
     @Test
     public void findAllByNameAndDepartmentAndCodeReturnTwoElementsInPageZero() {
-        String partialName = "fmc";
+        String partialName = "matematicos"; //without accent
         String partialDepartment = "DIM";
         String partialCode = "Di";
 
@@ -182,7 +182,7 @@ public class SubjectTests {
 
     @Test
     public void findAllByNameAndDepartmentAndCodeReturnCorrectOneElementInPageOne() {
-        String partialName = "fmc";
+        String partialName = "computacao"; //without accent
         String partialDepartment = "DIMA";
         String partialCode = "21";
         


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [x] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [ ] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
Veja #143.

**O que foi feito**
- Adicionado o operador da query `collation`, que permite ignorar acentos.
  - trecho de código adicionado: `$collation: { 'locale': 'pt', 'strength': 2 }`
